### PR TITLE
Switch powersave to ondemand due clock problem

### DIFF
--- a/rootdir/etc/lpm.rc
+++ b/rootdir/etc/lpm.rc
@@ -6,8 +6,8 @@ on init
 sysclktz 0
 
 on boot
-# Set cpu governor to powersave while in charging mode
-    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor powersave
+# Set cpu governor to ondemand while in charging mode
+    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor ondemand
 
 # Disable extra CPUs
     write /sys/devices/system/cpu/cpu1/online 0


### PR DESCRIPTION
Temp commit, because with ondemand the clock is able to go down to minimum frequency (250Mhz), unlike powersave (600Mhz). This commit should olny be as a temporary fix, until the powersave bug is fixed. I tested it for a few days now, the results are better this way.
